### PR TITLE
Fix Federated  Authenticator Flow - Retrieve user context from last authenticated localAuthenticator

### DIFF
--- a/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/FederatedAuthenticatorUtil.java
+++ b/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/FederatedAuthenticatorUtil.java
@@ -392,12 +392,26 @@ public class FederatedAuthenticatorUtil {
      *
      * @param context the authentication context
      */
+    //TODO - Find stepConfig with the username instead of relying on last one to be populated.
     public static void setUsernameFromFirstStep(AuthenticationContext context) throws AuthenticationFailedException {
         String username = null;
         AuthenticatedUser authenticatedUser;
-        StepConfig stepConfig = context.getSequenceConfig().getStepMap().get(context.getCurrentStep() - 1);
-        if (stepConfig.getAuthenticatedAutenticator().getApplicationAuthenticator() instanceof LocalApplicationAuthenticator) {
-            username = getLoggedInLocalUser(context);
+
+        // Try to get username from first authenticated Step
+        for (int i = context.getSequenceConfig().getStepMap().size() - 1; i >= 0; i--) {
+            if (null != context.getSequenceConfig().getStepMap().get(i).getAuthenticatedUser() &&
+                    null != context.getSequenceConfig().getStepMap().get(i).getAuthenticatedAutenticator() &&
+                    context.getSequenceConfig().getStepMap().get(i).getAuthenticatedAutenticator().getApplicationAuthenticator() instanceof LocalApplicationAuthenticator) {
+
+                username = context.getSequenceConfig().getStepMap().get(i).getAuthenticatedUser().toString();
+                if (log.isDebugEnabled()) {
+                    log.debug("username :" + username);
+                }
+                break;
+            }
+        }
+
+        if ( null != username) {
             authenticatedUser = getUsername(context);
         } else {
             //Get username from federated helper
@@ -419,28 +433,6 @@ public class FederatedAuthenticatorUtil {
         }
         context.setProperty(IdentityHelperConstants.USER_NAME, username);
         context.setProperty(IdentityHelperConstants.AUTHENTICATE_USER, authenticatedUser);
-    }
-
-    /**
-     * Get the user name from fist step.
-     *
-     * @param context the authentication context
-     * @return user name
-     */
-    public static String getLoggedInLocalUser(AuthenticationContext context) {
-        String username = "";
-        for (int i = context.getSequenceConfig().getStepMap().size() - 1; i >= 0; i--) {
-            if (context.getSequenceConfig().getStepMap().get(i).getAuthenticatedUser() != null &&
-                    context.getSequenceConfig().getStepMap().get(i).getAuthenticatedAutenticator()
-                            .getApplicationAuthenticator() instanceof LocalApplicationAuthenticator) {
-                username = context.getSequenceConfig().getStepMap().get(i).getAuthenticatedUser().toString();
-                if (log.isDebugEnabled()) {
-                    log.debug("username :" + username);
-                }
-                break;
-            }
-        }
-        return username;
     }
 
     /**


### PR DESCRIPTION
## Purpose

When trying out MFA authentication with conditional auth script enabled, if the user enters the wrong OTP code at the EmailOTP screen, they are not redirected to the retry attempt. Instead they are taken to the retry.do page with following exception : 

```
TID: [-1234] [] [2018-10-11 12:05:57,577] ERROR {org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator} -  Exception in Authentication Framework
java.lang.NullPointerException
        at org.wso2.carbon.extension.identity.helper.FederatedAuthenticatorUtil.setUsernameFromFirstStep(FederatedAuthenticatorUtil.java:399)
        at org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticator.initiateAuthenticationRequest(EmailOTPAuthenticator.java:160)
        at org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator.process(AbstractApplicationAuthenticator.java:71)
        at org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticator.process(EmailOTPAuthenticator.java:125)
        at org.wso2.carbon.identity.application.authentication.framework.handler.step.impl.DefaultStepHandler.doAuthentication(DefaultStepHandler.java:490)
        at org.wso2.carbon.identity.application.authentication.framework.handler.step.impl.DefaultStepHandler.handle(DefaultStepHandler.java:256)
        at org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.GraphBasedSequenceHandler.handleAuthenticationStep(GraphBasedSequenceHandler.java:271)
        at org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.GraphBasedSequenceHandler.handleNode(GraphBasedSequenceHandler.java:120)
        at org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.GraphBasedSequenceHandler.handle(GraphBasedSequenceHandler.java:105)
        at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultAuthenticationRequestHandler.handle(DefaultAuthenticationRequestHandler.java:132)
        at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator.handle(DefaultRequestCoordinator.java:159)
```

Samle auth script : 

```
function onInitialRequest(context) {
    retryCount = 5;
    executeBasicAuth(context, retryCount);
}

function executeBasicAuth(context, retryCount) {
    Log.info('--------------- executeBasicAuth retryCount ' + retryCount);

    executeStep(1, {
        onSuccess: function(context) {
            emailRetryCount = 5;
            executeEmailOTP(context, emailRetryCount);
        },
        onFail: function(context) {
            Log.info('--------------- fail retryCount ' + retryCount);
            --retryCount;
            if (retryCount > 0) {
                executeBasicAuth(context, retryCount);
            } else {
                Log.info('--------------- login failed ');
            }
        }
    });
}

function executeEmailOTP(context, emailRetryCount) {
    Log.info('--------------- executeEmailOTP retryCount ' + emailRetryCount);

    executeStep(2, {
        onSuccess: function(context) {
            Log.info('--------------- Email OTP Sucessful !');
        },
        onFail: function(context) {
            Log.info('--------------- fail retryCount ' + emailRetryCount);
            --emailRetryCount;
            if (emailRetryCount > 0) {
                executeEmailOTP(context, emailRetryCount);
            } else {
                Log.info('--------------- Email login failed ');
            }
        }
    });
}
```

## Approach

Fixed the NPE by checking if each step has an authenticatedAuthenticator populated, and retrieve the username from first non-null occurance.
