### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/component/helper/pom.xml
+++ b/component/helper/pom.xml
@@ -63,7 +63,26 @@
         </dependency>
     </dependencies>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <extensions>true</extensions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,10 +174,10 @@
     <properties>
         <carbon.identity.package.export.project.version>${project.version}
         </carbon.identity.package.export.project.version>
-        <carbon.identity.version>5.14.0</carbon.identity.version>
-        <carbon.kernel.version>4.6.0</carbon.kernel.version>
+        <carbon.identity.version>6.0.0-SNAPSHOT</carbon.identity.version>
+        <carbon.kernel.version>4.7.0</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.imp.pkg.version.range>[5.14.0, 6.0.0)
+        <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <!-- Pax Logging Version -->

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <properties>
         <carbon.identity.package.export.project.version>${project.version}
         </carbon.identity.package.export.project.version>
-        <carbon.identity.version>6.0.0-SNAPSHOT</carbon.identity.version>
+        <carbon.identity.version>6.0.0</carbon.identity.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16