### PR TITLE
Get stepConfig from subjectAttributeStep

### DIFF
--- a/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/FederatedAuthenticatorUtil.java
+++ b/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/FederatedAuthenticatorUtil.java
@@ -398,6 +398,13 @@ public class FederatedAuthenticatorUtil {
         String username = null;
         AuthenticatedUser authenticatedUser;
         StepConfig stepConfig = context.getSequenceConfig().getStepMap().get(context.getCurrentStep() - 1);
+        Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
+        for (StepConfig stepConfigIter : stepConfigMap.values()) {
+            if (stepConfigIter.isSubjectAttributeStep()) {
+                stepConfig = stepConfigIter;
+                break;
+            }
+        }
         if (stepConfig != null && stepConfig.getAuthenticatedAutenticator().getApplicationAuthenticator() instanceof
                 LocalApplicationAuthenticator) {
             username = getLoggedInLocalUser(context);

--- a/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/FederatedAuthenticatorUtil.java
+++ b/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/FederatedAuthenticatorUtil.java
@@ -397,13 +397,14 @@ public class FederatedAuthenticatorUtil {
     public static void setUsernameFromFirstStep(AuthenticationContext context) throws AuthenticationFailedException {
         String username = null;
         AuthenticatedUser authenticatedUser;
-        StepConfig stepConfig = context.getSequenceConfig().getStepMap().get(context.getCurrentStep() - 1);
+        StepConfig stepConfig = null;
         Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
         for (StepConfig stepConfigIter : stepConfigMap.values()) {
             if (stepConfigIter.isSubjectAttributeStep()) {
                 stepConfig = stepConfigIter;
                 break;
             }
+            stepConfig = context.getSequenceConfig().getStepMap().get(context.getCurrentStep() - 1);
         }
         if (stepConfig != null && stepConfig.getAuthenticatedAutenticator().getApplicationAuthenticator() instanceof
                 LocalApplicationAuthenticator) {


### PR DESCRIPTION
## Purpose
The current FederatedAuthenticatorUtil setUsernameFromFirstStep() method sets the username by considering only the previous authenticator step. The correct approach is to get the username from the subject attribute step. This PR fixes this flow by setting the username according to the subject attribute step. 

## Related Issues
- Issue https://github.com/wso2/product-is/issues/15431
- Issue https://github.com/wso2/product-is/issues/15367