### PR TITLE
Fix NPE in login flow

### DIFF
--- a/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/FederatedAuthenticatorUtil.java
+++ b/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/FederatedAuthenticatorUtil.java
@@ -399,8 +399,9 @@ public class FederatedAuthenticatorUtil {
         AuthenticatedUser authenticatedUser;
         StepConfig stepConfig = null;
         Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
-        for (StepConfig stepConfigIter : stepConfigMap.values()) {
-            if (stepConfigIter.isSubjectAttributeStep()) {
+        for (Map.Entry<Integer, StepConfig> stepConfigMapIter : stepConfigMap.entrySet()) {
+            StepConfig stepConfigIter = stepConfigMapIter.getValue();
+            if (stepConfigIter.isSubjectAttributeStep() && stepConfigMapIter.getKey() < context.getCurrentStep()) {
                 stepConfig = stepConfigIter;
                 break;
             }


### PR DESCRIPTION
### Purpose

Fixes NPE being thrown when the subject attribute step is not in a previously completed step.

### Approach

Consider only the steps that are before the current step.

### Related Issues

- https://github.com/wso2/product-is/issues/14951
