### PR TITLE
Prevent XEE attacks while reading XML files by seIncludeAware to false

### DIFF
--- a/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/util/IdentityHelperUtil.java
+++ b/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/util/IdentityHelperUtil.java
@@ -303,6 +303,7 @@ public class IdentityHelperUtil {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             factory.setNamespaceAware(true);
+            factory.setXIncludeAware(false);
             DocumentBuilder builder;
             builder = factory.newDocumentBuilder();
             Document doc;


### PR DESCRIPTION
## Purpose
- $subject
- The below PR only sets the feature to true : https://github.com/wso2-extensions/identity-extension-utils/pull/44
- From this PR, we setXIncludeAware to false for prevent from XXE attacks as per [1]

[1] https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxp-documentbuilderfactory-saxparserfactory-and-dom4j