### PR TITLE
Fix registry based authentication xml file read issue

### DIFF
--- a/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/IdentityHelperConstants.java
+++ b/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/IdentityHelperConstants.java
@@ -48,4 +48,6 @@ public class IdentityHelperConstants {
             = "authenticationPolicyAccountLockOnFailureMaxAttempts";
     public static final String AUTHENTICATION_POLICY_ACCOUNT_LOCK_TIME = "authenticationPolicyAccountLockTime";
     public static final String HYPHEN = "-";
+    public static final String ENABLE_TENANT_AUTHENTICATOR_OVERRIDE_FOR_AUTH_SEQUENCE
+            = "EnableTenantAuthenticatorOverrideForAuthSequence";
 }

--- a/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/util/IdentityHelperUtil.java
+++ b/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/util/IdentityHelperUtil.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
@@ -332,11 +333,18 @@ public class IdentityHelperUtil {
                     }
                 }
             }
+            if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityHelperConstants
+                    .ENABLE_TENANT_AUTHENTICATOR_OVERRIDE_FOR_AUTH_SEQUENCE))) {
+                context.setProperty(IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY, null);
+            }
         } catch (SAXException | ParserConfigurationException | IOException e) {
             throw new AuthenticationFailedException("Cannot get the parameter values from registry ", e);
         } catch (RegistryException e) {
-            context.setProperty(IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY,
-                    IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY);
+            if (!Boolean.parseBoolean(IdentityUtil.getProperty(IdentityHelperConstants
+                    .ENABLE_TENANT_AUTHENTICATOR_OVERRIDE_FOR_AUTH_SEQUENCE))) {
+                context.setProperty(IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY,
+                        IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY);
+            }
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }

--- a/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/util/IdentityHelperUtil.java
+++ b/component/helper/src/main/java/org/wso2/carbon/extension/identity/helper/util/IdentityHelperUtil.java
@@ -340,11 +340,8 @@ public class IdentityHelperUtil {
         } catch (SAXException | ParserConfigurationException | IOException e) {
             throw new AuthenticationFailedException("Cannot get the parameter values from registry ", e);
         } catch (RegistryException e) {
-            if (!Boolean.parseBoolean(IdentityUtil.getProperty(IdentityHelperConstants
-                    .ENABLE_TENANT_AUTHENTICATOR_OVERRIDE_FOR_AUTH_SEQUENCE))) {
-                context.setProperty(IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY,
-                        IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY);
-            }
+            context.setProperty(IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY,
+                    IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY);
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }


### PR DESCRIPTION
## Purpose
> $subject

As an alternative approach to address this issue, we could avoid setting the value in the context altogether. However, based on the current implementation logic, a value is expected to be present, and its absence leads to NPEs in multiple places (including other authenticators).

Therefore, the proposed fix is to explicitly clear the context variable when a registry-based authentication XML is detected.

### Related Issues
- https://github.com/wso2/product-is/issues/26612

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/7787

The local authenticators like SMS OTP, Email OTP doesn't honor the registry based authentication configurations. But previous federated authenticator based email OTP and SMS OTP based authenticators will honor the registry based authentication xml files [1]. Hence this fix is required for the master branch as those authenticators are supported in the product.

[1] - https://github.com/wso2-extensions/identity-outbound-auth-email-otp/blob/master/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java#L252